### PR TITLE
Fix the timezones on windows

### DIFF
--- a/absl/time/internal/cctz/src/time_zone_info.cc
+++ b/absl/time/internal/cctz/src/time_zone_info.cc
@@ -434,11 +434,7 @@ std::unique_ptr<ZoneInfoSource> FileZoneInfoSource::Open(
   // Map the time-zone name to a path name.
   std::string path;
   if (pos == name.size() || name[pos] != '/') {
-#ifdef PRINCIPIA_TZDIR
-    const char* tzdir = PRINCIPIA_TZDIR;
-#else
     const char* tzdir = "/usr/share/zoneinfo";
-#endif
     char* tzdir_env = nullptr;
 #if defined(_MSC_VER)
     _dupenv_s(&tzdir_env, nullptr, "TZDIR");

--- a/absl/time/internal/cctz/src/time_zone_libc.cc
+++ b/absl/time/internal/cctz/src/time_zone_libc.cc
@@ -42,7 +42,7 @@ namespace {
 
 #if defined(_WIN32) || defined(_WIN64)
 // Uses the globals: '_timezone', '_dstbias' and '_tzname'.
-// NOTE(phl): Microsoft, being in Redmont, counts West and not East.
+// NOTE(phl): Microsoft, being in Redmond, counts West and not East.
 auto tm_gmtoff(const std::tm& tm) -> decltype(_timezone + _dstbias) {
   const bool is_dst = tm.tm_isdst > 0;
   return -(_timezone + (is_dst ? _dstbias : 0));

--- a/absl/time/internal/cctz/src/time_zone_libc.cc
+++ b/absl/time/internal/cctz/src/time_zone_libc.cc
@@ -42,9 +42,10 @@ namespace {
 
 #if defined(_WIN32) || defined(_WIN64)
 // Uses the globals: '_timezone', '_dstbias' and '_tzname'.
+// NOTE(phl): Microsoft, being in Redmont, counts West and not East.
 auto tm_gmtoff(const std::tm& tm) -> decltype(_timezone + _dstbias) {
   const bool is_dst = tm.tm_isdst > 0;
-  return _timezone + (is_dst ? _dstbias : 0);
+  return -(_timezone + (is_dst ? _dstbias : 0));
 }
 auto tm_zone(const std::tm& tm) -> decltype(_tzname[0]) {
   const bool is_dst = tm.tm_isdst > 0;

--- a/absl/time/internal/cctz/src/time_zone_lookup.cc
+++ b/absl/time/internal/cctz/src/time_zone_lookup.cc
@@ -165,10 +165,17 @@ time_zone local_time_zone() {
   }
 #endif
 #if defined(_WIN32)
+// The time_zone_info.cc code is incapable of finding the time zones on Windows.
+// (It looks in /usr/share/zoneinfo...)  Since we only care about the local
+// time, fall back to the libc implementation.
+# ifdef PRINCIPIA
+  zone = "libc:localtime";
+# else
   std::string win32_tz = GetWindowsLocalTimeZone();
   if (!win32_tz.empty()) {
     zone = win32_tz.c_str();
   }
+# endif
 #endif
 
   // Allow ${TZ} to override to default zone.

--- a/msvc/abseil-cpp.props
+++ b/msvc/abseil-cpp.props
@@ -69,10 +69,7 @@
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <PreprocessorDefinitions>
-        PRINCIPIA;
-        PRINCIPIA_TZDIR=R"literal($(SolutionDir)\..\absl\time\internal\cctz\testdata\zoneinfo)literal"
-      </PreprocessorDefinitions>
+      <PreprocessorDefinitions>PRINCIPIA</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <TreatWarningAsError>true</TreatWarningAsError>
       <WarningLevel>Level3</WarningLevel>


### PR DESCRIPTION
0. Don't reference the test time zones, it's silly, the users don't have them.
1. No point in getting the timezone name from Windows since there is no code to properly build the time zones objects from the Windows database (which is in XML, not TZDB files).  We can use `"libc:localtime"` instead to go through the libc path, since we only ever care about local time.
2. Fix a sign error, Microsoft counts West, not East.